### PR TITLE
Null values support

### DIFF
--- a/Database.php
+++ b/Database.php
@@ -371,7 +371,11 @@ class Database
             if (is_object($value) || is_array($value) || is_bool($value)) {
                 $value = serialize($value);
             }
-            $query .= " '" . $this->escape($value) . "'";
+            if($value === null) {
+                $query .= ' NULL';
+            } else {
+                $query .= ' \'' . $this->escape($value) . '\'';
+            }
             $nr++;
             if ($nr != count($array)) {
                 $query .= ',';
@@ -457,7 +461,11 @@ class Database
                 if (is_object($v) || is_array($v) || is_bool($v)) {
                     $v = serialize($v);
                 }
-                $query .= ' `' . $k . "`='" . $this->escape($v) . "'";
+                if($value === null) {
+                    $query .= ' `' . $key . "`=NULL";
+                } else {
+                    $query .= ' `' . $key . "`='" . $this->escape($value) . "'";
+                }
                 $nr++;
                 if ($nr != count($fields)) {
                     $query .= ',';

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Reading the results can be done with the following functions:
 * `$db->row()` returns the first row that matches the query as an object
 
 * `$db->result_array()` returns all matches rows as an array containing row arrays
-* `$db->row_array()` returns the first row that matches the query as an object (stdClass)
+* `$db->row_array()` returns the first row that matches the query as an array
 
 Please note that you can call any of these functions also directly after the `$db->select()` call, like shown below:
 


### PR DESCRIPTION
This should fix the usage of PHP `null` values in `insert()` or `update()` calls, turning them into MySQL `NULL`.