### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/Database.php
+++ b/Database.php
@@ -587,7 +587,7 @@ class Database
     private function clean($str)
     {
         if (is_string($str)) {
-            if (!mb_detect_encoding($str, 'UTF-8', TRUE)) {
+            if (!mb_detect_encoding($str, 'UTF-8', true)) {
                 $str = utf8_encode($str);
             }
         }


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!